### PR TITLE
week15: Main_bj_2211_네트워크복구

### DIFF
--- a/junho/src/week15/Main_bj_2211_네트워크복구.java
+++ b/junho/src/week15/Main_bj_2211_네트워크복구.java
@@ -1,0 +1,84 @@
+package week15;
+
+import java.io.*;
+import java.util.*;
+
+public class Main_bj_2211_네트워크복구 {
+
+    static int N, M;
+    static int[][] graph;
+    static final int INF = Integer.MAX_VALUE / 2;
+
+    /**
+     * Dijkstra
+     */
+    static void solution() {
+        boolean[] v = new boolean[N + 1];
+        int[] dist = new int[N + 1];
+        int[] connect = new int[N + 1];
+
+        Arrays.fill(dist, INF);
+
+        PriorityQueue<int[]> pq = new PriorityQueue<>((o1, o2) -> Integer.compare(o1[1], o2[1]));
+        dist[1] = 0;
+        pq.offer(new int[]{1, dist[1]});
+
+        while (!pq.isEmpty()) {
+            int[] cur = pq.poll();
+            int minVertex = cur[0];
+            int min = cur[1];
+
+            if(v[minVertex]) continue;
+            v[minVertex] = true;
+
+            if(min > dist[minVertex]) {
+                continue;
+            }
+
+            // 갱신
+            for (int j = 1; j <= N; j++) {
+                if (!v[j] && graph[minVertex][j] != 0 && dist[j] > min + graph[minVertex][j]) {
+                    dist[j] = min + graph[minVertex][j];
+                    connect[j] = minVertex;
+                    pq.offer(new int[]{j, dist[j]});
+                }
+            }
+        }
+
+
+        StringBuilder sb = new StringBuilder();
+        int count = 0;
+        for (int i = 2; i <= N; i++) {
+            if (connect[i] == 0) {
+                continue;
+            }
+
+            count++;
+            sb.append(i).append(" ").append(connect[i]).append("\n");
+        }
+
+        System.out.println(count);
+        System.out.print(sb);
+    }
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        graph = new int[N + 1][N + 1];
+
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+            int s = Integer.parseInt(st.nextToken());
+            int t = Integer.parseInt(st.nextToken());
+            int c = Integer.parseInt(st.nextToken());
+            graph[s][t] = c;
+            graph[t][s] = c;
+        }
+
+        solution();
+    }
+
+}


### PR DESCRIPTION
https://www.acmicpc.net/problem/2211

### 문제 분석
- N개 [1, 1000] 개의 컴퓨터
- 컴퓨터 - 컴퓨터 에는 간선(회선)이 있고 회선 성능 고려함
- 컴퓨터 a - 컴퓨터 b로 바로 가는 비용보다 중간 컴퓨터 c를 거쳐서 가는 비용이 더 작을 수 있다.
- 해커 등장해서 모든 회선/컴퓨터를 차단했다. 
- 한 대 컴퓨터가 공격 받으면 한 대의 슈퍼 컴퓨터(1번 컴퓨터)에 공격받은 사실을 전달한다.
- 슈퍼 컴퓨터(1번 컴퓨터)는 공격 받은 컴퓨터에 네트워크를 이용해서 보안 패킷을 전송한다.

### 네트워크 복구 조건
1. 해커가 다시 공격할 수 있어 최소 개수의 회선만 복구하기. 복구한 후에 서로 다른 두 컴퓨터간 통신은 가능해야
2. 네트워크 복구 후 통신 가능 여부도 중요하지만, 해커에게 공격 받았을 때, 보안 패킷을 최단 시간으로 보내야. 
  - 슈퍼 컴퓨터가 다른 컴퓨터들과 통신하는데 걸리는 시간이 최소 시간이 되게, 원래 네트워크 통신하는데 걸리는 최소 시간보다 커지면 안됨

### 알고리즘 스케치

#### 1트 - MST 문제인가 싶어서 크루스칼 구현
- MST로 구현하면 전체 컴퓨터를 연결하는데의 최소 비용일 순 있겠지만. 슈퍼 컴퓨터 - 다른 컴퓨터의 비용은 최소가 아닐 수 있음
- 참고
> https://yunjae-gong.tistory.com/25 

#### 2트 - 다익스트라 알고리즘 구현
1. 양방향 그래프에 대한 인접 행렬 구현; 인접 리스트로 하면 더 빠르겠다
2. PriorityQueue를 이용한 다익스트라 알고리즘 구현 방법 적용
3. 마지막에 복구할 회선과 그 정점들을 출력해야해서 한 정점과 그 이웃 정점 중 최단 비용을 갖는 경우 이웃 정점 관계 기록(connect[] 배열)
4. connect 배열 정보를 출력하면서 count와 정점-정점 정보 출력하기
 -> 문제에서 순서는 상관없다 해서 그냥 출력