### PR TITLE
week 20 pg 258705 산 모양 타일링

### DIFF
--- a/byeongchang/src/week20/pg_258705_산_모양_타일링.java
+++ b/byeongchang/src/week20/pg_258705_산_모양_타일링.java
@@ -1,5 +1,6 @@
 package week20;
 
+// https://school.programmers.co.kr/learn/courses/30/lessons/258705
 public class pg_258705_산_모양_타일링 {
     static final int TRAPEZOID = 0;    // 사다리꼴
     static final int MOD = 10007;    // 나누기 연산을 위한 값

--- a/byeongchang/src/week20/pg_258705_산_모양_타일링.java
+++ b/byeongchang/src/week20/pg_258705_산_모양_타일링.java
@@ -49,6 +49,7 @@ public class pg_258705_산_모양_타일링 {
         }
 
 
+
     }
     static class TestCase {
         int n;


### PR DESCRIPTION
# 산 모양 타일링
[https://school.programmers.co.kr/learn/courses/30/lessons/258705](https://school.programmers.co.kr/learn/courses/30/lessons/258705)
## 문제 요약
- 여러 개의 정삼각형 타일을 붙여 사다리꼴을 만들고, 그 위에 부분부분 정사각형을 붙이 도형
- 도형을 정삼각형 또는 마름모 타일로 꽉 채우는 경우의 수 구하기
## 사용한 알고리즘, 자료구조
- 메모이제이션
- 모둘로 덧셈, 곱셈
- [https://ko.khanacademy.org/computing/computer-science/cryptography/modarithmetic/a/modular-addition-and-subtraction](https://ko.khanacademy.org/computing/computer-science/cryptography/modarithmetic/a/modular-addition-and-subtraction)
- [https://ko.khanacademy.org/computing/computer-science/cryptography/modarithmetic/a/modular-multiplication](https://ko.khanacademy.org/computing/computer-science/cryptography/modarithmetic/a/modular-multiplication)
## 해결하면서 고려했던 점
- 도형을 사다리꼴 윗 변에 있는 삼각형을 기준으로 분할한 다음, 왼쪽부터 오른쪽으로 하나씩 합쳐 경우의 수를 계산해 관계식을 도출함
- 메모이제이션 활용을 위해 분할한 개수만큼 int 이차원 배열을 생성해 저장
- 도형의 경우의 수를 나열할 때, 오른쪽 아래가 정삼각형 타일인 경우와, 마름모 타일인 경우로 나눠서 계산해야 함
- 다음에 붙이는 도형이 사다리꼴인 경우 + 오른쪽 아래가 정삼각형 타일인 경우의 수는 이전 도형의 정삼각형 타일의 경우의 수 X 2와 이전 도형의 마름모 타일의 경우의 수를 합한 값
- 다음에 붙이는 도형이 삼각형인 경우 + 오른쪽 아래가 정삼각형 타일인 경우의 수는 이전 도형의 정삼각형 타일의 경우의 수 X 3과 이전 도형의 마름모 타일의 경우의 수 X 2를 합한 값
- 다음에 붙이는 도형과 상관 없이 오른쪽 아래가 마름모 타일인 경우의 수는 이전 도형의 경우의 수의 합
- 오버플로우 방지하기 위해 모든 연산에 나머지 연산(%)을 수행해서 저장
- 오버플로우 발생을 놓칠 수 있어 Math.addExact(), Math.multiplyExact() 메소드를 이용해 오버플로우가 발생했을 때 Exception이 발생하도록 코드 작성

## 결과
![image](https://github.com/ps-AlgorithmStudy/Algorithm_JAVA/assets/81416039/04828526-d620-4c32-91e8-b1ff36ab110f)
