### PR TITLE
Week 23 파괴되지 않은 건물

### DIFF
--- a/byeongchang/src/week23/pg_92344_파괴되지_않는_건물.java
+++ b/byeongchang/src/week23/pg_92344_파괴되지_않는_건물.java
@@ -1,0 +1,64 @@
+package week23;
+
+//https://school.programmers.co.kr/learn/courses/30/lessons/92344
+public class pg_92344_파괴되지_않는_건물 {
+
+    public int solution(int[][] board, int[][] skill) {
+        int answer = 0;
+        int h = board.length;
+        int w = board[0].length;
+        int[][] sum = new int[h + 1][w + 1];   // 누적합 계산을 위한 배열
+        for(int[] s: skill) {
+            if(s[0]==1) s[5] *= -1;  // 파괴
+            sum[s[1]][s[2]] += s[5];
+            sum[s[1]][s[4]+1] -= s[5];   // 2차원 누적합은 세로 방향에 반대 값을 더해야 함
+            sum[s[3]+1][s[2]] -= s[5];   // 2차원 누적합은 가로 방향에 반대 값을 더해야 함
+            sum[s[3]+1][s[4]+1] += s[5];   // 2차원 누적합은 대각선 방향에 원래 값을 더해야 함(반대 값이 2번 더해지기 때문)
+        }
+        for(int i=0; i<h; i++) {
+            for(int j=0; j<w; j++) {
+                // 누적합 계산은 가로, 세로 값을 더하고 대각선 값을 빼주면 확정됨
+                if(i>0) sum[i][j] += sum[i-1][j];
+                if(j>0) sum[i][j] += sum[i][j-1];
+                if(i>0 && j>0) sum[i][j] -= sum[i-1][j-1];
+                // 확정된 누적합 계산으로 원래 맵 계산
+                board[i][j] += sum[i][j];
+                // 계산 결과가 양수면 건물이 파괴되지 않음
+                if(board[i][j] > 0) answer++;
+            }
+        }
+        return answer;
+    }
+
+
+    public static void main(String[] args) {
+        TestCase[] tc = new TestCase[2];
+        tc[0] = new TestCase(
+                new int[][]{{5,5,5,5,5}, {5,5,5,5,5}, {5,5,5,5,5}, {5,5,5,5,5}},
+                new int[][]{{1,0,0,3,4,4}, {1,2,0,2,3,2}, {2,1,0,3,1,2}, {1,0,1,3,3,1}},
+                10
+        );
+        tc[1] = new TestCase(
+                new int[][]{{1,2,3}, {4,5,6}, {7,8,9}},
+                new int[][]{{1,1,1,2,2,4}, {1,0,0,1,1,2}, {2,2,0,2,0,100}},
+                6
+        );
+
+        pg_92344_파괴되지_않는_건물 sol = new pg_92344_파괴되지_않는_건물();
+        for (TestCase t : tc) {
+            int result = sol.solution(t.board, t.skill);
+            System.out.println((result == t.result) + " sol: " + result + " ans: " + t.result);
+        }
+    }
+    static class TestCase {
+        int[][] board;
+        int[][] skill;
+        int result;
+
+        public TestCase(int[][] board, int[][] skill, int result) {
+            this.board = board;
+            this.skill = skill;
+            this.result = result;
+        }
+    }
+}


### PR DESCRIPTION
## 문제 요약
- 적 또는 아군의 스킬에 의해 맵 안의 건물의 체력이 줄어든거나 회복됨
- 최종적으로 체력이 0 이하가 된 건물은 파괴되며, 파괴되지 않은 건물의 개수를 반환하는 문제
## 사용한 알고리즘
- 누적합
## 해결하면서 고려했던 점
- 누적합으로 계산한 배열이 최종적으로 건물 체력에 영향을 주는 배열이 되도록 배열을 구성한다
```
0~5번 건물 중 0~3번 건물에 2 데미지를 주는 경우의 배열: [-2,0,0,0,2,0] -> 누적합 시 [-2,-2,-2,0,0]이 됨
```
- 반복 연산 횟수를 줄이기 위해, 누적합을 2차원으로 고려 -> 최종적으로 위에서 아래로 계산 + 왼쪽에서 오른쪽 방향으로 계산, 총  두 번의 계산으로 체력에 영향을 주는 배열이 완성됨
- 배열 설정 방법
-  - 시작 위치에 데미지(또는 치유) 표시
- - 시작에서 세로 방향으로 끝나는 좌표+1한 좌표에 반대 값 표시
- - 시작에서 가로 방향으로 끝나는 좌표+1한 좌표에 반대 값 표시
- - 시작에서 대각선 방향으로 끝나는 좌표+1한 좌표에 원래 값 표시(반대 값이 두 번 더해지기 때문)
```
예시
[2,0,-2]
[0,0,0]
[-2,0,2]
누적합 결과
[2,2,0]
[2,2,0]
[0,0,0]
```
- 체력에 영향을 주는 배열을 완성하고, 건물의 체력을 계산에 파괴되지 않은 건물의 수를 반환하면 끝

## 결과
![파괴되지 않은 건물](https://github.com/ps-AlgorithmStudy/Algorithm_JAVA/assets/81416039/6c39bd5a-4c61-4bf3-af23-6349eec5fac6)
